### PR TITLE
README.md を実行しやすく書き換えた

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,7 @@ has, etc!
 ### Running kannachan and Enabled to slack
 ```shell
 $ export HUBOT_SLACK_TOKEN=YOUR_TOKEN
-```
-
-```shell
 $ export PORT=80
-```
-
-```shell
 $ ./bin/hubot -a slack
 ```
 


### PR DESCRIPTION
現状のREADMEの実行例だと、コマンドが３行にまたがって表示されるため、
冗長です。そのため、実行例を１行にまとめ、一連の処理であることをわかりやすくしました。
